### PR TITLE
Add webpage footer

### DIFF
--- a/src/styles/_style.scss
+++ b/src/styles/_style.scss
@@ -3,6 +3,16 @@
  *  Docs: https://design-system.lib.umich.edu/
 **/
 
+:root {
+  --viewport-margin: var(--space-medium);
+}
+
+@media (min-width: 720px) {
+  :root {
+    --viewport-margin: var(--space-xx-large);
+  }
+}
+
 /*
  * DOCUMENT GLOBALS
 **/

--- a/src/styles/_style.scss
+++ b/src/styles/_style.scss
@@ -238,23 +238,29 @@ a.list-group-item:hover {
 footer.page-footer {
   background: var(--color-blue-400);
 
-  & ul {
+  & > ul {
     list-style: none;
     margin: 0;
     padding: 0;
 
-    & a {
-      display: inline-block;
+    & li > a {
+      display: block;
       padding: var(--space-x-small) 0;
+      color: white;
+      text-decoration: none;
 
       &:hover {
-        text-decoration-thickness: 2px;
+        text-decoration: underline;
       }
     }
   }
 
-  & a {
-    color: white;
+  & p a {
+    text-decoration: underline;
+
+    & :hover {
+      text-decoration-thickness: 2px;
+    }
   }
 }
 
@@ -271,20 +277,20 @@ footer.page-footer {
     margin-bottom: var(--space-medium);
   }
 
+  & > section {
+    margin-bottom: var(--space-x-large);
+  }
+
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(0, max-content));
+  grid-template-columns: 2fr 2fr 3fr;
   grid-auto-flow: column;
-  gap: var(--space-large);
+  gap: var(--space-xxx-large);
 }
 
 .page-footer__disclaimer {
   background: var(--color-blue-500);
   color: var(--color-blue-200);
   padding: var(--space-medium) 0;
-
-  & a {
-    color: var(--color-blue-200);
-  }
 
   & p {
     margin: 0;

--- a/src/styles/_style.scss
+++ b/src/styles/_style.scss
@@ -282,9 +282,8 @@ footer.page-footer {
   }
 
   display: grid;
-  grid-template-columns: 2fr 2fr 3fr;
-  grid-auto-flow: column;
-  gap: var(--space-xxx-large);
+  grid-template-columns: repeat(auto-fill, minmax(36ch, 1fr));
+  grid-gap: var(--space-xx-large);
 }
 
 .page-footer__disclaimer {

--- a/src/styles/_style.scss
+++ b/src/styles/_style.scss
@@ -14,8 +14,22 @@ body {
   font-size: 16px;
 }
 
-.main-container {
-  width: 1220px;
+/*
+ * Viewport Container
+ *
+ * Handles the need for page content to be centered
+ * in the visible view port window and manage the
+ * ammount of margin between the site and the edge
+ * of the screen's viewport.
+ */
+
+.viewport-container {
+  width: 100%;
+  max-width: 1280px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--viewport-margin);
+  padding-right: var(--viewport-margin);
 }
 
 /*
@@ -204,4 +218,75 @@ a.list-group-item:hover {
 #main-container #sidebar {
   padding-top: var(--space-medium);
   background: var(--color-blue-100);
+}
+
+
+/*
+ * Page Footer
+**/
+
+footer.page-footer {
+  background: var(--color-blue-400);
+
+  & ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    & a {
+      display: inline-block;
+      padding: var(--space-x-small) 0;
+
+      &:hover {
+        text-decoration-thickness: 2px;
+      }
+    }
+  }
+
+  & a {
+    color: white;
+  }
+}
+
+.page-footer__content {
+  color: var(--color-blue-100);
+  padding: var(--space-xxx-large) 0;
+
+  & h2 {
+    color: var(--color-blue-200);
+    font-size: 0.875rem;
+    font-weight: 800;
+    letter-spacing: 1.25px;
+    text-transform: uppercase;
+    margin-bottom: var(--space-medium);
+  }
+
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, max-content));
+  grid-auto-flow: column;
+  gap: var(--space-large);
+}
+
+.page-footer__disclaimer {
+  background: var(--color-blue-500);
+  color: var(--color-blue-200);
+  padding: var(--space-medium) 0;
+
+  & a {
+    color: var(--color-blue-200);
+  }
+
+  & p {
+    margin: 0;
+  }
+
+  @media screen and (min-width: 820px) {
+    & p {
+      display: "inline-block";
+    }
+
+    & p + p {
+      margin-left: var(--space-x-large);
+    }
+  }
 }

--- a/src/xsl/core/page-structure.xsl
+++ b/src/xsl/core/page-structure.xsl
@@ -786,7 +786,7 @@
           </div>
           <div class="page-footer__disclaimer">
             <div class="viewport-container">
-              <p>© 2021, Regents of the University of Michigan. Built with <a href="http://www.dspace.org/">DSpace</a> and the the <a href="https://design-system.lib.umich.edu/">U-M Library Design System</a>.</p>
+              <p>© 2021, Regents of the University of Michigan. Built with <a href="http://www.dspace.org/">DSpace</a>.</p>
             </div>
           </div>
         </footer>

--- a/src/xsl/core/page-structure.xsl
+++ b/src/xsl/core/page-structure.xsl
@@ -730,8 +730,8 @@
               <section>
                 <h2>University of Michigan Library</h2>
                 <ul>
-                  <li>
-                    913 S. University Avenue<br/>Ann Arbor, MI 48109
+                    <li>
+                        <a href="https://www.lib.umich.edu/">U-M Library</a>
                   </li>
                   <li>
                     <a href="https://publishing.umich.edu/">Michigan Publishing</a>
@@ -746,24 +746,18 @@
               <section>
                 <h2>About Deep Blue</h2>
                 <ul>
-                  <li>
-                    <a href="https://www.lib.umich.edu/collections/deep-blue-repositories">Deep Blue Repositories</a>
-                  </li>
-                  <li>
-                    <a href="https://www.lib.umich.edu/research-and-scholarship/help-research/share-and-preserve-your-work">Share and Preserve Your Work</a>
-                  </li>
-                  <li>
-                    <a href="https://www.lib.umich.edu/research-and-scholarship/data-services/share-and-preserve-your-data">Share and Preserve your Data</a>
-                  </li>
                     <li>
-                        <a>
-                            <xsl:attribute name="href">
-                                <xsl:value-of
-                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                                <xsl:text>/contact</xsl:text>
-                            </xsl:attribute>
-                            <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
-                        </a>
+                        <a href="https://www.lib.umich.edu/collections/deep-blue-repositories">Deep Blue Repositories</a>
+                    </li>
+                    <li>
+                    <a>
+                        <xsl:attribute name="href">
+                            <xsl:value-of
+                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+                            <xsl:text>/contact</xsl:text>
+                        </xsl:attribute>
+                        <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
+                    </a>
                     </li>
                     <li>
                         <a>
@@ -775,6 +769,9 @@
                             <i18n:text>xmlui.dri2xhtml.structural.feedback-link</i18n:text>
                         </a>
                     </li>
+                    <li>
+                        <a href="/static/about/deepbluefaq.html">Frequently Asked Questions</a>
+                    </li>
                 </ul>
               </section>
 
@@ -783,13 +780,13 @@
 
                 <p><a href="https://lib.umich.edu/about-us/policies/library-privacy-statement">Library Privacy Statement</a></p>
 
-                <p>Except where otherwise noted, this work is subject to a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 license</a>. For details and exceptions, see the <a href="/about-us/policies/copyright-policy">Library Copyright Policy</a>.</p>
+                <p>Works found in Deep Blue Documents are protected by copyright unless otherwise indicated.</p>
               </section>
             </div>
           </div>
           <div class="page-footer__disclaimer">
             <div class="viewport-container">
-              <p>© 2021, Regents of the University of Michigan. Built with <a href="http://www.dspace.org/">DSpace</a>.</p>
+              <p>© 2021, Regents of the University of Michigan. Built with <a href="http://www.dspace.org/">DSpace</a></p>
             </div>
           </div>
         </footer>

--- a/src/xsl/core/page-structure.xsl
+++ b/src/xsl/core/page-structure.xsl
@@ -721,65 +721,76 @@
     </xsl:template>
 
     <!-- Like the header, the footer contains various miscellaneous text, links, and image placeholders -->
-    <xsl:template name="buildFooter">
-        <footer>
-                <div class="row">
-                    <hr/>
-                    <div class="col-xs-7 col-sm-8">
-                        <div>
-                            <a href="http://www.dspace.org/" target="_blank">DSpace software</a> copyright&#160;&#169;&#160;2002-2016&#160; <a href="http://www.duraspace.org/" target="_blank">DuraSpace</a>
-                        </div>
-                        <div class="hidden-print">
-                            <a>
-                                <xsl:attribute name="href">
-                                    <xsl:value-of
-                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                                    <xsl:text>/contact</xsl:text>
-                                </xsl:attribute>
-                                <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
-                            </a>
-                            <xsl:text> | </xsl:text>
-                            <a>
-                                <xsl:attribute name="href">
-                                    <xsl:value-of
-                                            select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                                    <xsl:text>/feedback</xsl:text>
-                                </xsl:attribute>
-                                <i18n:text>xmlui.dri2xhtml.structural.feedback-link</i18n:text>
-                            </a>
-                        </div>
-                    </div>
-                    <div class="col-xs-5 col-sm-4 hidden-print">
-                        <div class="pull-right">
-                            <span class="theme-by">Theme by&#160;</span>
-                            <br/>
-                            <a title="Atmire NV" target="_blank" href="http://atmire.com">
-                                <img alt="Atmire NV" src="{concat($theme-path, 'images/atmire-logo-small.svg')}"/>
-                            </a>
-                        </div>
 
-                    </div>
-                </div>
-                <!--Invisible link to HTML sitemap (for search engines) -->
-                <a class="hidden">
-                    <xsl:attribute name="href">
-                        <xsl:value-of
-                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                        <xsl:text>/htmlmap</xsl:text>
-                    </xsl:attribute>
-                    <xsl:text>&#160;</xsl:text>
-                </a>
-            <p>&#160;</p>
+    
+    <xsl:template name="buildFooter">
+        <footer class="page-footer">
+          <div class="viewport-container">
+            <div class="page-footer__content">
+              <section>
+                <h2>University of Michigan Library</h2>
+                <ul>
+                  <li>
+                    913 S. University Avenue<br/>Ann Arbor, MI 48109
+                  </li>
+                  <li>
+                    <a href="https://www.lib.umich.edu/about-us/about-library/diversity-equity-inclusion-and-accessibility/accessibility">Accessibility</a>
+                  </li>
+
+                </ul>
+              </section>
+
+              <section>
+                <h2>About Deep Blue</h2>
+                <ul>
+                  <li>
+                    <a href="https://www.lib.umich.edu/collections/deep-blue-repositories">Deep Blue Repositories</a>
+                  </li>
+                  <li>
+                    <a href="https://www.lib.umich.edu/research-and-scholarship/help-research/share-and-preserve-your-work">Share and Preserve Your Work</a>
+                  </li>
+                  <li>
+                    <a href="https://www.lib.umich.edu/research-and-scholarship/data-services/share-and-preserve-your-data">Share and Preserve your Data</a>
+                  </li>
+                    <li>
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:value-of
+                                        select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+                                <xsl:text>/contact</xsl:text>
+                            </xsl:attribute>
+                            <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
+                        </a>
+                    </li>
+                    <li>
+                        <a>
+                            <xsl:attribute name="href">
+                                <xsl:value-of
+                                    select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
+                                <xsl:text>/feedback</xsl:text>
+                            </xsl:attribute>
+                            <i18n:text>xmlui.dri2xhtml.structural.feedback-link</i18n:text>
+                        </a>
+                    </li>
+                </ul>
+              </section>
+
+              <section>
+                <h2>Privacy and copyright</h2>
+
+                <p><a href="https://lib.umich.edu/about-us/policies/library-privacy-statement">Library Privacy Statement</a></p>
+
+                <p>Except where otherwise noted, this work is subject to a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 license</a>. For details and exceptions, see the <a href="/about-us/policies/copyright-policy">Library Copyright Policy</a>.</p>
+              </section>
+            </div>
+          </div>
+          <div class="page-footer__disclaimer">
+            <div class="viewport-container">
+              <p>© 2021, Regents of the University of Michigan. Built with <a href="http://www.dspace.org/">DSpace</a> and the the <a href="https://design-system.lib.umich.edu/">U-M Library Design System</a>.</p>
+            </div>
+          </div>
         </footer>
     </xsl:template>
-
-
-    <!--
-            The meta, body, options elements; the three top-level elements in the schema
-    -->
-
-
-
 
     <!--
         The template to handle the dri:body element. It simply creates the ds-body div and applies

--- a/src/xsl/core/page-structure.xsl
+++ b/src/xsl/core/page-structure.xsl
@@ -750,23 +750,13 @@
                         <a href="https://www.lib.umich.edu/collections/deep-blue-repositories">Deep Blue Repositories</a>
                     </li>
                     <li>
-                    <a>
-                        <xsl:attribute name="href">
-                            <xsl:value-of
-                                select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                            <xsl:text>/contact</xsl:text>
-                        </xsl:attribute>
-                        <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
-                    </a>
-                    </li>
-                    <li>
                         <a>
                             <xsl:attribute name="href">
                                 <xsl:value-of
                                     select="/dri:document/dri:meta/dri:pageMeta/dri:metadata[@element='contextPath'][not(@qualifier)]"/>
-                                <xsl:text>/feedback</xsl:text>
+                                <xsl:text>/contact</xsl:text>
                             </xsl:attribute>
-                            <i18n:text>xmlui.dri2xhtml.structural.feedback-link</i18n:text>
+                            <i18n:text>xmlui.dri2xhtml.structural.contact-link</i18n:text>
                         </a>
                     </li>
                     <li>

--- a/src/xsl/core/page-structure.xsl
+++ b/src/xsl/core/page-structure.xsl
@@ -734,6 +734,9 @@
                     913 S. University Avenue<br/>Ann Arbor, MI 48109
                   </li>
                   <li>
+                    <a href="https://publishing.umich.edu/">Michigan Publishing</a>
+                  </li>
+                  <li>
                     <a href="https://www.lib.umich.edu/about-us/about-library/diversity-equity-inclusion-and-accessibility/accessibility">Accessibility</a>
                   </li>
 


### PR DESCRIPTION
## What's new?

A webpage footer has been added with content as defined in our [project plan](https://docs.google.com/document/d/1MtadZd-RnSY_x7hezG-93-RwzkBquqG_Xkdc_a2oCa0/edit?usp=sharing). See screenshot below.

## Preview

Note: "Send feedback" has been removed.

![image](https://user-images.githubusercontent.com/1678665/113587779-46155600-95fd-11eb-97dd-bdee83291a03.png)
